### PR TITLE
feat: allow custom, user-defined, GET parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ For full and up to date instructions for the different available plugin
 installation methods, refer to [How to Install a Plugin](https://coreruleset.org/docs/concepts/plugins/#how-to-install-a-plugin)
 in the official CRS documentation.
 
+## Configuration
+
+The settings for this plugin reside in `plugins/google-oauth2-config.conf`.
+
+### tx.google-oauth2-plugin_whitelisted_parameters
+
+Here you can whitelist additional GET parameters which you are sending
+using callback URL and are not standard to Google OAuth2. Use this syntax:
+/param1/ /param2/ /param3/
+
+Default value:
+
 ## Testing
 
 After installation, plugin should be tested, for example, using these two commands:  
@@ -26,7 +38,7 @@ with the following message in the log:
 
 ## License
 
-Copyright (c) 2022 OWASP CRS project. All rights reserved.
+Copyright (c) 2022-2025 OWASP CRS project. All rights reserved.
 
 The OWASP CRS and its official plugins are distributed
 under Apache Software License (ASL) version 2. Please see the enclosed LICENSE

--- a/plugins/google-oauth2-before.conf
+++ b/plugins/google-oauth2-before.conf
@@ -51,9 +51,13 @@ SecRule TX:GOOGLE-OAUTH2-PLUGIN_CALLBACK_DETECTED "@eq 1" \
     t:none,\
     nolog,\
     ver:'google-oauth2-plugin/1.0.0',\
-    chain
-    SecRule ARGS_NAMES "!@pm state code scope authuser hd prompt" \
-        "setvar:'tx.google-oauth2-plugin_callback_detected=0'"
+    chain"
+    SecRule ARGS_NAMES "@rx ^.*$" \
+        "capture,\
+        setvar:'tx.google-oauth2-plugin_arg_name_%{tx.0}=/%{tx.0}/',\
+        chain"
+        SecRule TX:/^google-oauth2-plugin_arg_name_/ "!@within /state/ /code/ /scope/ /authuser/ /hd/ /prompt/ %{tx.google-oauth2-plugin_whitelisted_parameters}" \
+            "setvar:'tx.google-oauth2-plugin_callback_detected=0'"
 
 SecRule TX:GOOGLE-OAUTH2-PLUGIN_CALLBACK_DETECTED "@eq 1" \
     "id:9505130,\

--- a/plugins/google-oauth2-before.conf
+++ b/plugins/google-oauth2-before.conf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 # OWASP CRS Plugin
-# Copyright (c) 2021-2024 CRS project. All rights reserved.
+# Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
 # The OWASP CRS plugins are distributed under
 # Apache Software License (ASL) version 2

--- a/plugins/google-oauth2-config.conf
+++ b/plugins/google-oauth2-config.conf
@@ -45,11 +45,11 @@
 # Here you can whitelist additional GET parameters which you are sending
 # using callback URL and are not standard to Google OAuth2. Use this syntax:
 # setvar:'tx.google-oauth2-plugin_whitelisted_parameters=/param1/ /param2/ /param3/'
-SecAction \
- "id:9505020,\
-  phase:1,\
-  nolog,\
-  pass,\
-  t:none,\
-  ver:'google-oauth2-plugin/1.0.0',\
-  setvar:'tx.google-oauth2-plugin_whitelisted_parameters='"
+#SecAction \
+# "id:9505020,\
+#  phase:1,\
+#  nolog,\
+#  pass,\
+#  t:none,\
+#  ver:'google-oauth2-plugin/1.0.0',\
+#  setvar:'tx.google-oauth2-plugin_whitelisted_parameters='"

--- a/plugins/google-oauth2-config.conf
+++ b/plugins/google-oauth2-config.conf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 # OWASP CRS Plugin
-# Copyright (c) 2021-2024 CRS project. All rights reserved.
+# Copyright (c) 2021-2025 CRS project. All rights reserved.
 #
 # The OWASP CRS plugins are distributed under
 # Apache Software License (ASL) version 2
@@ -41,3 +41,15 @@
 #   pass,\
 #   nolog,\
 #   setvar:'tx.google-oauth2-plugin_enabled=0'"
+
+# Here you can whitelist additional GET parameters which you are sending
+# using callback URL and are not standard to Google OAuth2. Use this syntax:
+# setvar:'tx.google-oauth2-plugin_whitelisted_parameters=/param1/ /param2/ /param3/'
+SecAction \
+ "id:9505020,\
+  phase:1,\
+  nolog,\
+  pass,\
+  t:none,\
+  ver:'google-oauth2-plugin/1.0.0',\
+  setvar:'tx.google-oauth2-plugin_whitelisted_parameters='"


### PR DESCRIPTION
Some users are sending custom GET parameters using callback URL which needs to be whitelisted for plugin to work properly. This PR adds support for whitelisting such parameters.

Related discussion: https://github.com/coreruleset/google-oauth2-plugin/issues/1#issuecomment-2599027469