### PR TITLE
fix: whitelist 'iss' parameter

### DIFF
--- a/plugins/google-oauth2-before.conf
+++ b/plugins/google-oauth2-before.conf
@@ -36,8 +36,8 @@ SecRule &ARGS_GET:scope "@eq 1" \
         "chain"
         SecRule &ARGS_GET:code "@eq 1" \
             "chain"
-            SecRule ARGS_GET:scope "@rx ^(?:email|profile|openid)(?: email| profile| openid| https://www\.googleapis\.com/auth/(?:userinfo\.email|userinfo\.profile|userinfo\.openid|drive\.metadata\.readonly|drive\.file|drive\.readonly))+$" \
-                "t:none,t:urlDecodeUni,t:lowercase,\
+            SecRule ARGS_GET:scope "@rx (?i)^(?:email|profile|openid)(?: email| profile| openid| https://www\.googleapis\.com/auth/(?:userinfo\.email|userinfo\.profile|userinfo\.openid|drive\.metadata\.readonly|drive\.file|drive\.readonly))+$" \
+                "t:none,\
                 setvar:'tx.google-oauth2-plugin_callback_detected=1'"
 
 # This rule is guarding against extra parameters which should not appear in
@@ -56,7 +56,7 @@ SecRule TX:GOOGLE-OAUTH2-PLUGIN_CALLBACK_DETECTED "@eq 1" \
         "capture,\
         setvar:'tx.google-oauth2-plugin_arg_name_%{tx.0}=/%{tx.0}/',\
         chain"
-        SecRule TX:/^google-oauth2-plugin_arg_name_/ "!@within /state/ /code/ /scope/ /authuser/ /hd/ /prompt/ %{tx.google-oauth2-plugin_whitelisted_parameters}" \
+        SecRule TX:/^google-oauth2-plugin_arg_name_/ "!@within /state/ /code/ /scope/ /authuser/ /hd/ /prompt/ /iss/ %{tx.google-oauth2-plugin_whitelisted_parameters}" \
             "setvar:'tx.google-oauth2-plugin_callback_detected=0'"
 
 SecRule TX:GOOGLE-OAUTH2-PLUGIN_CALLBACK_DETECTED "@eq 1" \

--- a/tests/regression/google-oauth2-plugin/9505130.yaml
+++ b/tests/regression/google-oauth2-plugin/9505130.yaml
@@ -16,7 +16,7 @@ tests:
           port: 80
           method: GET
           version: HTTP/1.1
-          uri: /get?state=test&code=test&scope=email+profile+https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email
+          uri: /get?state=test&code=test&scope=email+profile+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email
         output:
           log:
             no_expect_ids: [930120]
@@ -32,7 +32,23 @@ tests:
           port: 80
           method: GET
           version: HTTP/1.1
-          uri: /get?state=test&code=test&scope=email+profile+https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email&inject=data
+          uri: /get?state=test&code=test&scope=email+profile+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email&inject=data
         output:
           log:
             expect_ids: [930120]
+  - test_id: 3
+    desc: "Check that plugin is excluding rule 930120 for 'scope' parameter for valid Google OAuth2 callback using 'iss' parameter"
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: "OWASP CRS test agent"
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          method: GET
+          version: HTTP/1.1
+          uri: /get?state=test&iss=https%3A%2F%2Faccounts.google.com&code=test&scope=email+profile+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email
+        output:
+          log:
+            no_expect_ids: [930120]


### PR DESCRIPTION
- whitelisting `iss` parameter
- removing double URL decode
- few small tweaks